### PR TITLE
[feat] 중고거래 페이지 레이아웃 제작 #2 

### DIFF
--- a/carrot/src/assets/ProductList.css
+++ b/carrot/src/assets/ProductList.css
@@ -1,0 +1,38 @@
+:root {
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: rgba(255, 255, 255, 0.87);
+  color: #242424;
+}
+
+.market__list {
+  /* max-width는 나중에 바뀔수도! */
+  max-width: 1280px;
+  margin: 0 auto;
+}
+.market__nav__info ol {
+  display: flex;
+  flex-direction: row;
+  gap: 0.6rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.market__nav__info ol li {
+  font-size: 0.9rem;
+  color: #737373;
+}
+
+.market__now__location {
+  font-size: 1.8rem;
+  font-weight: bold;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+}
+
+.market__item__section {
+  display: flex;
+  gap: 1rem; /* 간격 조절 */
+}

--- a/carrot/src/components/product-list/ProductAside.jsx
+++ b/carrot/src/components/product-list/ProductAside.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export default function ProductAside() {
+  return (
+    <section>
+      <aside>
+        <header>
+          <h3>필터</h3>
+          <a href='#'>초기화</a>
+        </header>
+        <section>
+          <div>
+            <input type='checkbox' name='isTradable' id='tradable' />
+            <label htmlFor='isTradable'>거래 가능만 보기</label>
+          </div>
+          <div className='market__aside__filter'>
+            <h4>위치</h4>
+            <p>서울특별시 서초구</p>
+            <div className='aside__filter aside__location'>
+              <input type='radio' name='locationFilter' id='1' />
+              <label htmlFor='locationFilter'>서초동</label>
+            </div>
+          </div>
+          <div className='market__aside__filter'>
+            <h4>카테고리</h4>
+            <div className='aside__filter aside__category'>
+              <input type='radio' name='categoryFilter' id='1' />
+              <label htmlFor='categoryFilter'>디지털기기</label>
+            </div>
+          </div>
+          <div className='market__aside__filter'>
+            <h4>가격</h4>
+            <div className='aside__filter aside__price'>
+              <button>나눔</button>
+              <button>5,000원 이하</button>
+              <button>10,000원 이하</button>
+              <button>20,000원 이하</button>
+              <div className='aside__price__input'>
+                <input type='number' name='minPrice' id='minPrice' /> -{' '}
+                <input type='number' name='maxPrice' id='maxPrice' />
+              </div>
+              <input type='submit' value='적용하기' />
+            </div>
+          </div>
+        </section>
+      </aside>
+    </section>
+  );
+}

--- a/carrot/src/components/product-list/ProductItemList.jsx
+++ b/carrot/src/components/product-list/ProductItemList.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import Card from 'react-bootstrap/Card';
+import products from '../../assets/products.json';
+
+export default function ProductItemList() {
+  return (
+    <section className='Product__list list--right'>
+      <Card style={{ width: '18rem' }}>
+        <Card.Img
+          variant='top'
+          src='https://img.kr.gcp-karroter.net/origin/article/202506/b4da17bf16801e51b8c88938532108dc9058ed947d487724a5a586851e27957e_0.webp?q=82&s=300x300&t=crop&f=webp'
+        />
+        <Card.Body>
+          <Card.Title>Card Title</Card.Title>
+          <Card.Text>15,000원</Card.Text>
+          <div className='card__item__info'>
+            <span>서초동</span>
+            <span>・</span>
+            <span>34분 전</span>
+          </div>
+        </Card.Body>
+      </Card>
+    </section>
+  );
+}

--- a/carrot/src/pages/ProductList.jsx
+++ b/carrot/src/pages/ProductList.jsx
@@ -1,5 +1,28 @@
 import React from 'react';
+import '../assets/ProductList.css';
+//Bootstrap
+import 'bootstrap/dist/css/bootstrap.min.css';
+//Components
+import ProductAside from '../components/product-list/ProductAside';
+import ProductItemList from '../components/product-list/ProductItemList';
 
 export default function ProductList() {
-  return <div>ProductList</div>;
+  return (
+    <div className='market__list'>
+      <nav className='market__nav__info'>
+        <ol>
+          <li>홈</li>
+          <li>{'>'}</li>
+          <li>중고거래</li>
+        </ol>
+      </nav>
+      <h2 className='market__now__location'>
+        서울특별시 서초구 서초동 중고거래
+      </h2>
+      <section className='market__item__section'>
+        <ProductAside />
+        <ProductItemList />
+      </section>
+    </div>
+  );
 }


### PR DESCRIPTION
#2 
**기능 요약**
중고거래 페이지 레이아웃 만들기

### 새로 생성한 페이지
- [carrot/src/pages/ProductList.jsx](https://github.com/goorm-team-study-cc/carrot-clone/compare/main...feature/prd-list-layout?expand=1#diff-466ad87d2c9edf745d9d1f0fc7a750bc4bbc426e965a79d8f4ac91ba71c947ac) : 중고거래 리스트 페이지 컴포넌트
- [carrot/src/components/product-list/ProductAside.jsx](https://github.com/goorm-team-study-cc/carrot-clone/compare/main...feature/prd-list-layout?expand=1#diff-851bb261cc62cb0d0bff0d975f415e489ab1dd70364b0b2aa03c81f9aff8362e) : 중고거래 리스트 왼쪽 필터링 부분 컴포넌트
- [carrot/src/components/product-list/ProductItemList.jsx](https://github.com/goorm-team-study-cc/carrot-clone/compare/main...feature/prd-list-layout?expand=1#diff-eb4d05cc9bf630e0727a2a9e4a6a86615c30abf66201ee985093c5cbf6a7fd14) : 중고거래 리스트 오른쪽 물품 나열
- [carrot/src/assets/ProductList.css](https://github.com/goorm-team-study-cc/carrot-clone/compare/main...feature/prd-list-layout?expand=1#diff-40e8f58bf8f4f48ad57720675a7c6fa49dbf16413c46f765a8712ce1231b63d3) : 중고거래 리스트 부분 스타일


